### PR TITLE
Fix for scopebuddy.py not finding config.json

### DIFF
--- a/scopebuddy.py
+++ b/scopebuddy.py
@@ -21,7 +21,7 @@ parser.add_argument(
 parser.add_argument("-s",
                     "--shodan", default=True, action="store_false", help="Disable Shodan search against discovered IP addresses")
 parser.add_argument("-c",
-                    "--config", default=f"{os.path.dirname(sys.argv[0])}/config.json", help="Provide a config file containing API keys for additional services (e.g. Shodan)")
+                    "--config", default=f"config.json", help="Provide a config file containing API keys for additional services (e.g. Shodan)")
 args = parser.parse_args()
 shodan_enable = args.shodan
 


### PR DESCRIPTION
Hi, great project! I was running into the following error: `Config file doesn't exist. A sample file is included in the repository for this project. [Errno 2] No such file or directory: '/config.json`. My take is that the code you had for getting the current working directory wasn't working for some reason. Luckily, removing it allows the script to find the config.json file in the current working directory, so it was an easy fix.